### PR TITLE
upgrade to latest version of alpine (3.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 MAINTAINER Michael Venezia <mvenezia@gmail.com>
 
 ENV     TERRAFORM_VERSION=0.8.6


### PR DESCRIPTION
new version of alpine docker image was released (3.7), we should be using it.

part of samsung-cnct/issues#97